### PR TITLE
fix(setup): 修复安装失败的问题

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+bs4

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,58 @@
+# -*- coding:utf-8 -*-
 import setuptools
-from flomo import __version__
+import pathlib
+import ast
+import typing as ty
+
+REQUIREMENTS_SPEC = 'requirements.txt'
+PACKAGE_ENTRY = 'flomo'
+VERSION_FLAG = '__version__'
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+
+def read_requirements() -> ty.List[str]:
+    p = pathlib.Path(__file__).parent / REQUIREMENTS_SPEC
+    with open(str(p), 'r', encoding='utf-8') as f:
+        rows = f.readlines()
+
+    requirements = list()
+    for r in rows:
+        r = r.strip()
+        if not r:
+            continue
+
+        if r.startswith('#'):
+            continue
+
+        requirements.append(r)
+
+    return requirements
+
+
+def get_version() -> str:
+    p = pathlib.Path(__file__).parent / PACKAGE_ENTRY / '__init__.py'
+
+    version_row = None
+    with open(str(p), 'r', encoding='utf-8') as f:
+        r = f.readline()
+        while (r):
+            if r.startswith(VERSION_FLAG):
+                version_row = r
+                break
+
+            r = f.readline()
+
+    _, version = version_row.split('=')
+    version = version.strip()
+    version = ast.literal_eval(version)
+    return version
+
+
 setuptools.setup(
     name="flomo",
-    version=__version__,
+    version=get_version(),
     author="Benature Wang",
     author_email="wbenature@163.com",
     description="Flomo API (third party)",
@@ -14,7 +60,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/Benature/flomo",
     packages=setuptools.find_packages(),
-    install_requires=['requests', 'bs4'],
+    install_requires=read_requirements(),
     # entry_points={
     #     'console_scripts': [
     #         'autolatex=autolatex:excel2table',


### PR DESCRIPTION
## 问题
安装过程中 setup.py 会首先引入 `__init__.py` ，此时代码中需求的 `requests` 尚未安装。

## 修复
- 从 `__init__.py` 中直接读取 `__version__` 字符串
- 为方便开发 & 调试，将 `install_require` 拆分为独立的文件
